### PR TITLE
Fix for perl v5.18.2 in Ubuntu 14.04 LTS

### DIFF
--- a/assemblathon_stats.pl
+++ b/assemblathon_stats.pl
@@ -298,7 +298,7 @@ sub sequence_statistics{
 							  1000000  => '1M',
 							  10000000 => '10M');
 
-	foreach my $size qw(1000 10000 100000 1000000 10000000){
+	foreach my $size (qw(1000 10000 100000 1000000 10000000)){
 		my $matches = grep { $_ > $size } @{$data{$type}{lengths}};
 		my $percent = sprintf("%.1f", ($matches / $count) * 100);
 
@@ -425,7 +425,7 @@ sub sequence_statistics{
     $bases{N} = ($seq =~ tr/N/N/);
 	
 	my $base_count = 0;
-	foreach my $base qw (A C G T N){
+	foreach my $base (qw(A C G T N)){
 		my $percent = sprintf("%.2f", ($bases{$base} / $length) * 100);
 		$desc = "$type %$base";
 		printf "%${w}s %10s\n", $desc, $percent;


### PR DESCRIPTION
The latest upgrade to Perl in my system does not like the foreach syntax with qw() without surrounding the array in parenthesis, so it crashes. Adding the parenthesis seems to fix the problem. 

Also, I have the impression of having seen some warnings about this before.
